### PR TITLE
Add support for `base64:…` arg for `unlock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,17 +141,20 @@ This will show the raw content as stored in the repository. So even if `cat my-s
 After you freshly clone a repository which contains files which have been encrypted by `git-conceal`, you need to provide the symmetric key that your coworkers would have shared with you to decrypt it:
 
 ```bash
-# Option 1: Provide the key via an environment variable (base64 encoded)
+# Option 1: Provide the key via an environment variable (base64 encoded). Recommended on CI.
 export GIT_SECRETS_KEY="YOUR_BASE64_KEY"
 git-conceal unlock env:GIT_SECRETS_KEY
 
-# Option 2: Provide a path to a from file containing the raw binary, 32 bytes key
+# Option 2: Provide the Base64-encoded key as command line argument. (Only use locally, as on CI this could leak the key in logs).
+git-conceal unlock "base64:c3VwcG9zZWRseS15b3VyLWJpbmFyeS1zZWNyZXRrZXk="
+
+# Option 3: Provide a path to a from file containing the raw binary, 32 bytes key.
 git-conceal unlock /path/to/key.bin
 
-# Option 3: Provide it via stdin (expects raw binary, 32 bytes as input)
+# Option 4: Provide it via stdin (expects raw binary, 32 bytes as input)
 cat /path/to/key.bin | git-conceal unlock -
-# Or convert from base64:
-echo "YOUR_BASE64_KEY" | base64 -d | git-conceal unlock -
+# Or convert from base64. (Only use locally, as on CI this could leak the key in logs).
+echo "c3VwcG9zZWRseS15b3VyLWJpbmFyeS1zZWNyZXRrZXk=" | base64 -d | git-conceal unlock -
 ```
 
 This will:

--- a/src/key.rs
+++ b/src/key.rs
@@ -74,6 +74,7 @@ impl Key {
     /// Supports:
     /// - `"-"` for reading from stdin (raw binary format, 32 bytes)
     /// - `"env:VARNAME"` for reading from environment variable (base64 encoded)
+    /// - `"base64:BASE64_KEY"` for reading from base64-encoded key
     /// - File path for reading from a file (raw binary format, 32 bytes)
     ///
     /// Returns the encryption key.
@@ -94,6 +95,8 @@ impl Key {
                 format!("Failed to read key from environment variable {}", env_var)
             })?;
             Self::from_base64(&key_b64)
+        } else if let Some(base64_key) = key_source.strip_prefix("base64:") {
+            Self::from_base64(base64_key)
         } else {
             // Read from file (raw binary format)
             Self::from_file(Path::new(key_source))
@@ -389,6 +392,14 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Environment variable name cannot be empty"));
+    }
+
+    #[test]
+    fn test_read_from_source_base64() {
+        let key = test_key();
+        let b64 = key.to_base64();
+        let loaded_key = Key::read_from_source(&format!("base64:{}", b64)).unwrap();
+        assert_eq!(loaded_key.as_bytes(), key.as_bytes());
     }
 
     // Note: Testing stdin reading is complex in unit tests as it requires

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,8 @@ enum Commands {
         /// Key source
         #[arg(
             value_name = "KEY_SOURCE",
-            long_help = "- 'env:VARNAME': base64-encoded key in environment variable\n\
+            long_help = "- 'env:VARNAME': base64-encoded key in environment variable (recommended on CI)\n\
+                         - 'base64:BASE64_KEY': base64-encoded key\n\
                          - '-': raw binary key from stdin\n\
                          - <PATH>: raw binary key from file"
         )]
@@ -398,6 +399,8 @@ fn init_instructions(key_b64: &str) -> String {
               - From environment variable (base64):
                 export GIT_SECRETS_KEY='{key_b64}'
                 {bin_name} unlock env:GIT_SECRETS_KEY
+              - From base64-encoded key in the command line:
+                {bin_name} unlock "base64:{key_b64}"
               - From file (raw binary, 32 bytes):
                 {bin_name} unlock /path/to/key.bin
               - From stdin (raw binary, 32 bytes):


### PR DESCRIPTION
## Why?

To make it easier to unlock a repository locally given the base64 of the key (which is how the key would likely be shared between coworkers, e.g. this is how it's shared in our internal Secret Store), this adds support for `git conceal unlock "base64:…"` syntax.

## How?

Similar to the `git conceal unlock env:<VARNAME>` syntax to read the base64-encoded key from an env var (ideal for CI), this `git conceal unlock "base64:<base64key>` syntax is most suitable for developers that need to unlock their local working copy from the base64 key they'd retrive from our Secret Store.

Without that change, providing the base64 key from the Secret Store to `git conceal` required to use something like `echo "<base64key>" | base64 -d | git conceal unlock -`, which worked but was not super natural. Another possible way was to `export GIT_CONCEAL_KEY="<base64key>"` then `git conceal unlock env:GIT_CONCEAL_KEY`, but that required setting a one-off env var for little benefit. With that new syntax, it'll be easier to unlock a repo from a base64-encoded key like the ones shared in Secret Store, making the onboarding instructions easier.

## Testing

 - Run `cargo build --release` from this PR's head branch
 - Checkout the head branch of one of the PRs of a repo in which I've already prepared the migration to `git-conceal`, like of https://github.com/woocommerce/woocommerce-android/pull/14979 or https://github.com/Automattic/pocket-casts-android/pull/4841, so you have a repo on which to test that command on
 - Search "git-conceal" in the Secret Store and copy the base64 key for the corresponding repo
 - From the working copy of the repo you picked for testing, run:
```bash
$ git conceal unlock "base64:$(pbpaste)"
```
(or alternatively, paste the key manually in your terminal in that command, i.e. `git conceal unlock "base64:<paste key here>"`)
