### PR TITLE
Support `--json` output for `status` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,8 @@ dependencies = [
  "hmac",
  "indoc",
  "rand",
+ "serde",
+ "serde_json",
  "serial_test",
  "sha2",
  "tempfile",
@@ -555,6 +557,12 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
@@ -832,6 +840,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +894,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ git2 = { version = "^0.20", features = ["vendored-openssl", "vendored-libgit2"] 
 anyhow = "^1.0"
 indoc = "^2.0"
 const_format = "^0.2"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
 
 [target.'cfg(windows)'.dependencies]
 windows-permissions = "0.2.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,11 @@ fn cmd_status(files: Vec<String>, json: bool) -> Result<()> {
 
     if files.is_empty() {
         // Show repository status
-        let is_unlocked = repo.is_unlocked()?;
+        let repo_status = if repo.is_unlocked()? {
+            status::LockStatus::Unlocked
+        } else {
+            status::LockStatus::Locked
+        };
         let filters_configured = repo.filters_configured()?;
         let has_untracked_files = repo.has_untracked_files()?;
         let encrypted_files: Vec<_> = repo
@@ -259,7 +263,7 @@ fn cmd_status(files: Vec<String>, json: bool) -> Result<()> {
 
         let status = status::RepositoryStatus {
             repository: repo.workdir().to_string_lossy().into_owned(),
-            status: if is_unlocked { "unlocked" } else { "locked" }.to_string(),
+            status: repo_status,
             filters_configured,
             encrypted_files,
             has_untracked_files,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod filter;
 mod fs_helpers;
 mod key;
 mod repo;
+mod status;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
@@ -81,6 +82,9 @@ enum Commands {
         /// Files to check (if empty, shows repository status)
         #[arg(value_name = "FILE")]
         files: Vec<String>,
+        /// Output status in JSON format
+        #[arg(long)]
+        json: bool,
     },
     /// Key management commands
     #[command(about = "Manage encryption key")]
@@ -143,7 +147,7 @@ fn main() -> Result<()> {
         Commands::Init => cmd_init(),
         Commands::Unlock { key_source } => cmd_unlock(key_source),
         Commands::Lock { force } => cmd_lock(force),
-        Commands::Status { files } => cmd_status(files),
+        Commands::Status { files, json } => cmd_status(files, json),
         Commands::Key { key_cmd } => cmd_key(key_cmd),
         Commands::Filter { filter_cmd } => cmd_filter(filter_cmd),
     }
@@ -240,54 +244,54 @@ fn cmd_lock(force: bool) -> Result<()> {
     Ok(())
 }
 
-fn cmd_status(files: Vec<String>) -> Result<()> {
+fn cmd_status(files: Vec<String>, json: bool) -> Result<()> {
     let repo = repo::Repo::discover()?;
 
     if files.is_empty() {
         // Show repository status
-        println!("Repository: {}", repo.workdir().display());
         let is_unlocked = repo.is_unlocked()?;
-        println!(
-            "Status: {}",
-            if is_unlocked { "unlocked" } else { "locked" }
-        );
-
         let filters_configured = repo.filters_configured()?;
-        println!(
-            "Filters configured: {}",
-            if filters_configured { "yes" } else { "no" }
-        );
+        let has_untracked_files = repo.has_untracked_files()?;
+        let encrypted_files: Vec<_> = repo
+            .find_filtered_files()?
+            .collect::<Result<Vec<_>>>()
+            .context("Failed to get file path")?;
 
-        println!("\nTracked files configured for encryption by Git filter:");
-        let mut has_files = false;
-        for file_result in repo.find_filtered_files()? {
-            let file = file_result?;
-            println!("  🔒 {}", file.display());
-            has_files = true;
-        }
-        if !has_files {
-            println!("  (none)");
-        }
+        let status = status::RepositoryStatus {
+            repository: repo.workdir().to_string_lossy().into_owned(),
+            status: if is_unlocked { "unlocked" } else { "locked" }.to_string(),
+            filters_configured,
+            encrypted_files,
+            has_untracked_files,
+        };
 
-        // Only show warning if there are actually untracked files
-        if repo.has_untracked_files()? {
-            println!(
-                "\nNote: You have untracked files in your working copy. Even if some\n\
-                of those new files match the filter patterns in `.gitattributes`,\n\
-                they won't be listed here until you `git add` them to the staging area."
-            );
+        if json {
+            println!("{}", serde_json::to_string_pretty(&status)?);
+        } else {
+            print!("{}", status);
         }
     } else {
         // Check status for specific files
-        for file_str in &files {
-            let file_path = std::path::Path::new(file_str);
-            let is_filtered = repo.is_filtered_file(file_path)?;
-            let status = if is_filtered {
-                "🔒 Encrypted in the repository"
-            } else {
-                "👀 Not encrypted in the repository"
-            };
-            println!("{:20}: {}", file_str, status);
+        let file_statuses: Vec<status::FileStatus> = files
+            .iter()
+            .map(|file_str| {
+                let file_path = std::path::Path::new(file_str);
+                let is_filtered = repo.is_filtered_file(file_path)?;
+                Ok(status::FileStatus {
+                    file: file_path.to_path_buf(),
+                    encrypted: is_filtered,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let status_list = status::FileStatusList {
+            files: file_statuses,
+        };
+
+        if json {
+            println!("{}", serde_json::to_string_pretty(&status_list)?);
+        } else {
+            print!("{}", status_list);
         }
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,79 @@
+use serde::Serialize;
+use std::fmt;
+use std::path::PathBuf;
+
+#[derive(Serialize)]
+pub struct RepositoryStatus {
+    pub repository: String,
+    pub status: String,
+    pub filters_configured: bool,
+    pub encrypted_files: Vec<PathBuf>,
+    pub has_untracked_files: bool,
+}
+
+impl fmt::Display for RepositoryStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Repository: {}", self.repository)?;
+        writeln!(f, "Status: {}", self.status)?;
+        writeln!(
+            f,
+            "Filters configured: {}",
+            if self.filters_configured { "yes" } else { "no" }
+        )?;
+
+        writeln!(
+            f,
+            "\nTracked files configured for encryption by Git filter:"
+        )?;
+        if self.encrypted_files.is_empty() {
+            writeln!(f, "  (none)")?;
+        } else {
+            for file in &self.encrypted_files {
+                writeln!(f, "  🔒 {}", file.to_string_lossy())?;
+            }
+        }
+
+        // Only show warning if there are actually untracked files
+        if self.has_untracked_files {
+            writeln!(
+                f,
+                "\nNote: You have untracked files in your working copy. Even if some\n\
+                of those new files match the filter patterns in `.gitattributes`,\n\
+                they won't be listed here until you `git add` them to the staging area."
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+pub struct FileStatus {
+    pub file: PathBuf,
+    pub encrypted: bool,
+}
+
+impl fmt::Display for FileStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let status = if self.encrypted {
+            "🔒 Encrypted in the repository"
+        } else {
+            "👀 Not encrypted in the repository"
+        };
+        write!(f, "{:20}: {}", self.file.to_string_lossy(), status)
+    }
+}
+
+#[derive(Serialize)]
+pub struct FileStatusList {
+    pub files: Vec<FileStatus>,
+}
+
+impl fmt::Display for FileStatusList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for file_status in &self.files {
+            writeln!(f, "{}", file_status)?;
+        }
+        Ok(())
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -3,9 +3,25 @@ use std::fmt;
 use std::path::PathBuf;
 
 #[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LockStatus {
+    Locked,
+    Unlocked,
+}
+
+impl fmt::Display for LockStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LockStatus::Locked => write!(f, "locked"),
+            LockStatus::Unlocked => write!(f, "unlocked"),
+        }
+    }
+}
+
+#[derive(Serialize)]
 pub struct RepositoryStatus {
     pub repository: String,
-    pub status: String,
+    pub status: LockStatus,
     pub filters_configured: bool,
     pub encrypted_files: Vec<PathBuf>,
     pub has_untracked_files: bool,


### PR DESCRIPTION
## What

Allows to easily use the output in scripts if needed (e.g. pipe that status output through `jq`, etc)

## How

 - Introduce dedicated `struct RepositoryStatus` object to represent the status reported by `git-conceal status`
 - Introduce dedicated `struct FileStatusList` and `struct FileStatus` objects to represent the status of files list reported by `git-conceal status file1 file2 …`
 - Make those structs implement both the `Serialize` trait from the `serde` crate—to handle JSON serialization (using `#[derive(Serialize)]` for implicit implementation of it)—and the `fmt::Display` trait—to handle plain text rendering.
 - Which allows the implementation of `cmd_status` to build those objects representations regardless of the output format requested, and only at the end decide to `println!` those results either as JSON (`serde_json::to_string_pretty(&status)`) or as plain text (`print!("{}", status)`). (Making the code nicer than if I did giant `if / else` branches for all the cases)

## Testing Instructions

 - Run `cargo build --release` from this PR's head branch
 - Checkout the head branch of one of the PRs of a repo in which I've already prepared the migration to `git-conceal`, like of https://github.com/woocommerce/woocommerce-android/pull/14979 or https://github.com/Automattic/pocket-casts-android/pull/4841, so you have a repo on which to test that command on
 - Then, from the working copy of such a test repo, run some commands to test the feature, like:
```bash
$ export PATH="<path-to-git-conceal-repo>/target/release:$PATH"
$ git-conceal status --json | jq
$ git conceal status --json | jq -r '.encrypted_files[]'
$ git conceal status --json secret.properties | jq
$ git conceal status --json secret.properties foo bar baz | jq '.files | map({key:.file, value:.encrypted}) | from_entries'
```