### PR TITLE
Warn if `.gitattributes` is encrypted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "indoc",
+ "owo-colors",
  "rand",
  "serde",
  "serde_json",
@@ -692,6 +693,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "parking_lot"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ indoc = "^2.0"
 const_format = "^0.2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
+owo-colors = "4"
 
 [target.'cfg(windows)'.dependencies]
 windows-permissions = "0.2.4"

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,5 +1,6 @@
 use crate::repo::Repo;
 use anyhow::{Context, Result};
+use owo_colors::OwoColorize;
 use serde::Serialize;
 use serde_json;
 use std::fmt;
@@ -7,6 +8,7 @@ use std::path::PathBuf;
 
 pub fn cmd_status<S: AsRef<str>>(files: &[S], json: bool) -> Result<()> {
     let repo = Repo::discover()?;
+    let is_gitattributes_encrypted: bool;
 
     if files.is_empty() {
         // Show repository status
@@ -21,6 +23,7 @@ pub fn cmd_status<S: AsRef<str>>(files: &[S], json: bool) -> Result<()> {
             .find_filtered_files()?
             .collect::<Result<Vec<_>>>()
             .context("Failed to get file path")?;
+        is_gitattributes_encrypted = encrypted_files.contains(&PathBuf::from(".gitattributes"));
 
         let status = RepositoryStatus {
             repository: repo.workdir().to_string_lossy().into_owned(),
@@ -48,6 +51,7 @@ pub fn cmd_status<S: AsRef<str>>(files: &[S], json: bool) -> Result<()> {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
+        is_gitattributes_encrypted = repo.is_filtered_file(&PathBuf::from(".gitattributes"))?;
 
         let status_list = FileStatusList {
             files: file_statuses,
@@ -58,6 +62,18 @@ pub fn cmd_status<S: AsRef<str>>(files: &[S], json: bool) -> Result<()> {
         } else {
             print!("{}", status_list);
         }
+    }
+
+    // Warn on stderr if the `.gitattributes` file is encrypted (regardless of output format)
+    if is_gitattributes_encrypted {
+        let warning_message = format!(
+            "Warning: The `{}` filter is applied to your `.gitattributes` file.",
+            crate::repo::FILTER_NAME
+        );
+        eprintln!("\n⚠️  {}", warning_message.red());
+        eprintln!("That file should never be encrypted, as it will prevent the filters from being applied during checkout.\n\
+                   Add the following line to your `.gitattributes` file to exclude it from encryption:\n");
+        eprintln!("{}", "```\n.gitattributes !filter !diff\n```".yellow());
     }
 
     Ok(())


### PR DESCRIPTION
Closes #16

> [!NOTE]
> This PR is built on top of #18 (to benefit from its code cleanup)

## What

This PR makes `git-conceal status` print a warning if `.gitattributes` file would be encrypted, with the suggestion to add `.gitattributes !filter !diff` line for it in `.gitattributes` itself to prevent that from happening.

## Why

The `.gitattributes` file should never have the `filter=git-conceal` attribute applied, because that would mean that the `.gitattributes` file itself would get encrypted (which would make it impossible for git to parse on checkout of a fresh clone, and thus would not allow git to know which files to decrypt…)

## Context

This case should rarely be encountered in practice, as we don't expect users to explicitly add `.gitattributes filter=git-conceal` in their `.gitattributes` file explicitly on purpose. But it could happen if the `.gitattributes` file were to accidentally match a generic pattern (e.g. if the user has added `.* filter=git-conceal` to encrypt all files starting with a dot… which would accidentally include `.gitattributes` itself), so it's still nice to warn about it if we detect such edge case happening.

## Testing

 - Checkout this PR's HEAD branch, and run `make build-release`. Then `export PATH=$PWD/target/release:$PATH` to have the built release `git-conceal` binary in your PATH.
 - `cd` into your working copy of PCAndroid and checkout the HEAD branch of [this pocket-casts-android PR](https://github.com/Automattic/pocket-casts-android/pull/4841)
 - Run `git conceal status`, and observe the warning is not printed. Same with `git conceal status --json`.
 - Edit `.gitattributes` and add a line at the end like `.git* filter=git-conceal`
 - Run `git conceal status`, and observe the warning is now shown. Same with `git conceal status --json`.
 - Revert your changes to `.gitattributes`

<img width="489" height="158" alt="cat .gitattributes" src="https://github.com/user-attachments/assets/bbf33c69-17b9-486e-9eef-4e0396b0a557" />

<img width="756" height="441" alt="git conceal status" src="https://github.com/user-attachments/assets/7c3b7a73-40ee-4806-939d-c6834b7bfa66" />
